### PR TITLE
PT-63-fixing migration files docker copy command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Copy the migrations directory
-COPY pkg/db/migrations /app/migrations
+COPY pkg/migrations /app/migrations
 
 # Download all dependencies and tidy up
 RUN go mod download && go mod tidy


### PR DESCRIPTION
# PT-63 - fix dockerfile copy comand

### Description
Not sure why it was copying the db/migration files which as causing it to not make any tables.