### PR TITLE
[PT-122] - Add Headers in CORS Middlewear

### DIFF
--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -9,6 +9,6 @@ func CORSMiddleware() gin.HandlerFunc {
 	return cors.New(cors.Config{
 		AllowAllOrigins: true,
 		AllowMethods:    []string{"GET", "POST"},
-		AllowHeaders:    []string{"Origin", "Content-Type"},
+		AllowHeaders:    []string{"Origin", "Content-Type", "x-api-key", "AccessKey"}, // x-api-key for solana and AccessKey for debank
 	})
 }


### PR DESCRIPTION
# [PT-122](https://0xbase.atlassian.net/browse/PT-122) - Add Headers in CORS Middlewear

### Description

Allow access key and AccessKey in CORS headers


[PT-122]: https://0xbase.atlassian.net/browse/PT-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ